### PR TITLE
Bugfix + Command Enhancement

### DIFF
--- a/src/commands/daily.js
+++ b/src/commands/daily.js
@@ -29,6 +29,8 @@ exports.run = async (client, message) => {
       // worth of scrobbles
       if (timestamp === null) {
         timestamp = moment().subtract(1, `days`);
+      } else {
+        timestamp = moment(timestamp);
       }
 
       const lUsername = user.get(`lastFMUsername`);

--- a/src/commands/plays.js
+++ b/src/commands/plays.js
@@ -2,9 +2,33 @@ const { stringify } = require(`querystring`);
 const fetch = require(`node-fetch`);
 
 exports.run = async (client, message, args) => {
-  const artistName = args.join(` `);
+  let artistName = args.join(` `);
+  const Users = client.sequelize.import(`../models/Users`);
+    if (!artistName) {
+      const user = await Users.findOne({
+        where: {
+          discordUserID: message.author.id
+        }
+      });
+      if (!user) return message.reply(`you haven't registered your Last.fm ` +
+      `account, therefore, I can't check what you're listening to. To set ` +
+      `your Last.fm nickname, do \`&login <lastfm username\`.`);
+      const username = user.lastFMUsername;
+      const params = {
+        method: `user.getrecenttracks`,
+        user: username,
+        api_key: client.config.lastFM.apikey,
+        format: `json`
+      };
+      const query = stringify(params);
+      const data = await fetch(client.config.lastFM.endpoint + query)
+        .then(r => r.json());
+      const track = data.recenttracks.track[0];
+      if (!track[`@attr`])
+        return message.reply(`currently, you are not listening to anything.`);
+      else artistName = track.artist[`#text`];
+    }
   if (!artistName) return message.reply(`you have not defined an artist!`);
-  const Users = client.sequelize.import(`../models/Users.js`);
   try {
     const user = await Users.findOne({
       where: {

--- a/src/commands/plays.js
+++ b/src/commands/plays.js
@@ -4,31 +4,30 @@ const fetch = require(`node-fetch`);
 exports.run = async (client, message, args) => {
   let artistName = args.join(` `);
   const Users = client.sequelize.import(`../models/Users`);
-    if (!artistName) {
-      const user = await Users.findOne({
-        where: {
-          discordUserID: message.author.id
-        }
-      });
-      if (!user) return message.reply(`you haven't registered your Last.fm ` +
-      `account, therefore, I can't check what you're listening to. To set ` +
-      `your Last.fm nickname, do \`&login <lastfm username\`.`);
-      const username = user.lastFMUsername;
-      const params = {
-        method: `user.getrecenttracks`,
-        user: username,
-        api_key: client.config.lastFM.apikey,
-        format: `json`
-      };
-      const query = stringify(params);
-      const data = await fetch(client.config.lastFM.endpoint + query)
-        .then(r => r.json());
-      const track = data.recenttracks.track[0];
-      if (!track[`@attr`])
-        return message.reply(`currently, you are not listening to anything.`);
-      else artistName = track.artist[`#text`];
-    }
-  if (!artistName) return message.reply(`you have not defined an artist!`);
+  if (!artistName) {
+    const user = await Users.findOne({
+      where: {
+        discordUserID: message.author.id
+      }
+    });
+    if (!user) return message.reply(`you haven't registered your Last.fm ` +
+    `account, therefore, I can't check what you're listening to. To set ` +
+    `your Last.fm nickname, do \`&login <lastfm username\`.`);
+    const username = user.lastFMUsername;
+    const params = {
+      method: `user.getrecenttracks`,
+      user: username,
+      api_key: client.config.lastFM.apikey,
+      format: `json`
+    };
+    const query = stringify(params);
+    const data = await fetch(client.config.lastFM.endpoint + query)
+      .then(r => r.json());
+    const track = data.recenttracks.track[0];
+    if (!track[`@attr`])
+      return message.reply(`currently, you are not listening to anything.`);
+    else artistName = track.artist[`#text`];
+  }
   try {
     const user = await Users.findOne({
       where: {


### PR DESCRIPTION
I've fixed a bug on the `&daily` command that would cause an error to be thrown due to running `.utc()` method on a timestamp which isn't an instance of `moment`. That's fixed.

Edited `&plays` command to allow no arguments, allowing the user to run the command with the current listening track (copied code from `&whoknows`)